### PR TITLE
Fixes #5

### DIFF
--- a/app/src/router/crawl.py
+++ b/app/src/router/crawl.py
@@ -1,5 +1,7 @@
 from app.src.graph.graph import MainGraph
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, HTTPException
+from bson.errors import InvalidId
+from bson.objectid import ObjectId
 
 # Create a router instance
 router = APIRouter()
@@ -12,14 +14,33 @@ def crawl(
      query: str = Query(..., description="What is your aidiate query?"),
      chat_id: str = Query(None, description="Optional chat ID for the conversation")
 ):
-    result = main_graph.invoke(query, chat_id)
+    # Validate chat_id format if provided
+    if chat_id is not None:
+        try:
+            # Attempt to convert to ObjectId to validate format
+            ObjectId(chat_id)
+        except InvalidId:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid chat_id format. Must be a valid ObjectId string."
+            )
     
-    # Get the chat_id from the result
-    response_chat_id = result.get("chat_id", chat_id)
-    
-    return {
-        "query": query,
-        "chat_id": response_chat_id,
-        "result": result,
-        "success": True
-    }
+    try:
+        result = main_graph.invoke(query, chat_id)
+        
+        # Get the chat_id from the result (could be a new one if chat_id was None)
+        response_chat_id = result.get("chat_id", chat_id)
+        
+        return {
+            "query": query,
+            "chat_id": response_chat_id,
+            "result": result,
+            "success": True
+        }
+    except Exception as e:
+        # Log the error for debugging (you may want to use proper logging)
+        print(f"Error processing request: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while processing your request. Please try again without a chat_id or with a valid chat_id."
+        )


### PR DESCRIPTION
Added validation for chat_id format
Added error handling around the main graph invocation

Now the endpoint will handle invalid chat_ids in two ways:

1. If the chat_id format is invalid (not a valid ObjectId string), it will return a 400 error

2. If the chat_id is valid but doesn't exist in the database, it will return a 500 error with a suggestion to try again without a chat_id
